### PR TITLE
require relative path

### DIFF
--- a/lib/websocket-eventmachine-base.rb
+++ b/lib/websocket-eventmachine-base.rb
@@ -1,1 +1,1 @@
-require File.expand_path('../websocket/eventmachine/base', __FILE__)
+require 'websocket/eventmachine/base'


### PR DESCRIPTION
graceful, and require a absolute path will cause a crash in packaged(eg. exerb) applications.
