### PR TITLE
Ensure that frame errors are reported and errors are reported as strings.

### DIFF
--- a/lib/websocket/eventmachine/base.rb
+++ b/lib/websocket/eventmachine/base.rb
@@ -158,7 +158,7 @@ module WebSocket
           trigger_onopen
           handle_open(@handshake.leftovers) if @handshake.leftovers
         else
-          trigger_onerror(@handshake.error)
+          trigger_onerror(@handshake.error.to_s)
           close
         end
       end
@@ -194,6 +194,7 @@ module WebSocket
           when :invalid_payload_encoding then 1007
           else 1002
         end
+        trigger_onerror(error.to_s)
         close(error_code)
         unbind
       end


### PR DESCRIPTION
When testing error handling, I was testing an invalid control frame (that was greater than 125 bytes) but the "onerror" callback wasn't getting called which I was expecting to be called.

This pull request includes a change to ensure that all errors reported to "onerror" are strings and that any frame decoding errors call the "onerror" callback, just like handshaking errors do.
