### PR TITLE
Update base.rb

### DIFF
--- a/lib/websocket/eventmachine/base.rb
+++ b/lib/websocket/eventmachine/base.rb
@@ -76,14 +76,19 @@ module WebSocket
       end
 
       # Close connection
+      # if we received code == 1001 it means that the connection with client has gone. We close the socket without sincronitzation with client.
       # @return [Boolean] true if connection is closed immediately, false if waiting for other side to close connection
       def close(code = 1000, data = nil)
-        if @state == :open
-          @state = :closing
-          return false if send(data, :type => :close, :code => code)
-        else
-          send(data, :type => :close) if @state == :closing
+        if code == 1001
           @state = :closed
+        else
+          if @state == :open
+            @state = :closing
+            return false if send(data, :type => :close, :code => code)
+          else
+            send(data, :type => :close) if @state == :closing
+            @state = :closed
+          end
         end
         close_connection_after_writing
         true


### PR DESCRIPTION
Went I make some test I found that if the connection with the client has gone and I want to close it the socket of this connection remains in state ESTABLISHED after the client response a close request. But it cann't the client has gone and it will not be back ;). We need to close the socket in order to avoid DDoS because after some time all sockets will be in use. I use code 1001 to close the socket without sending a close message to client. Following docs I found in https://developer.mozilla.org/es/docs/Web/API/CloseEvent.

If I'm wrong with that solution please tell me. I need to close the socket if client not make to me a ping after X seconds and I cannot find another way to do it.